### PR TITLE
fix: configure hot partition thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,9 @@ cloudwatchLogs:
 
 analysis:
   sampleSize: 100
+  hotPartitionThreshold: 5
+  hotPartitionThresholds:
+    high-traffic-table: 12
 ```
 
 ### AWS setup

--- a/src/analyzers/__tests__/dynamodb.test.ts
+++ b/src/analyzers/__tests__/dynamodb.test.ts
@@ -150,4 +150,27 @@ describe('HotPartitionAnalyzer', () => {
     const findings = await analyzer.analyze(graph);
     expect(findings).toHaveLength(0);
   });
+
+  it('uses per-table thresholds when configured', async () => {
+    const analyzer = new HotPartitionAnalyzer(2, { Orders: 4 });
+    const graph: SystemGraph = {
+      nodes: [
+        { id: 'fn:a', type: 'function', name: 'a', file: 'a.ts' },
+        { id: 'fn:b', type: 'function', name: 'b', file: 'b.ts' },
+        { id: 'table:dynamo:Orders', type: 'table', name: 'Orders', databaseType: 'dynamodb' },
+        { id: 'table:dynamo:Users', type: 'table', name: 'Users', databaseType: 'dynamodb' },
+      ],
+      edges: [
+        { from: 'fn:a', to: 'table:dynamo:Orders', type: 'query' },
+        { from: 'fn:b', to: 'table:dynamo:Orders', type: 'query' },
+        { from: 'fn:a', to: 'table:dynamo:Users', type: 'query' },
+        { from: 'fn:b', to: 'table:dynamo:Users', type: 'query' },
+      ],
+    };
+
+    const findings = await analyzer.analyze(graph);
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0].metadata).toMatchObject({ tableName: 'Users', threshold: 2 });
+  });
 });

--- a/src/analyzers/dynamodb.ts
+++ b/src/analyzers/dynamodb.ts
@@ -115,9 +115,11 @@ export class HotPartitionAnalyzer implements Analyzer {
   name = 'HotPartitionAnalyzer';
 
   private readonly hotThreshold: number;
+  private readonly tableThresholds: Record<string, number>;
 
-  constructor(hotThreshold = 5) {
+  constructor(hotThreshold = 5, tableThresholds: Record<string, number> = {}) {
     this.hotThreshold = hotThreshold;
+    this.tableThresholds = tableThresholds;
   }
 
   async analyze(graph: SystemGraph): Promise<Finding[]> {
@@ -140,13 +142,14 @@ export class HotPartitionAnalyzer implements Analyzer {
     }
 
     for (const [tableId, accessors] of tableAccessCount) {
-      if (accessors.size >= this.hotThreshold) {
-        const tableNode = graph.nodes.find((n) => n.id === tableId) as Extract<
-          GraphNode,
-          { type: 'table' }
-        >;
-        if (!tableNode) continue;
+      const tableNode = graph.nodes.find((n) => n.id === tableId) as Extract<
+        GraphNode,
+        { type: 'table' }
+      >;
+      if (!tableNode) continue;
 
+      const threshold = this.tableThresholds[tableNode.name] ?? this.hotThreshold;
+      if (accessors.size >= threshold) {
         // Also check edge frequency for repeated access patterns
         let maxFreq = 0;
         for (const [key, freq] of edgeFrequency) {
@@ -162,6 +165,7 @@ export class HotPartitionAnalyzer implements Analyzer {
           metadata: {
             tableName: tableNode.name,
             accessorCount: accessors.size,
+            threshold,
             maxEdgeFrequency: maxFreq,
           },
         });

--- a/src/cli/commands/analyze.ts
+++ b/src/cli/commands/analyze.ts
@@ -418,9 +418,15 @@ export async function runAnalyze(options: AnalyzeOptions = {}): Promise<void> {
   let findings: Awaited<ReturnType<typeof runAllAnalyzers>>;
   {
     const s = mkSpinner('Running analyzers...');
+    const hotPartitionThreshold = config.analysis?.hotPartitionThreshold;
+    const hotPartitionThresholds = config.analysis?.hotPartitionThresholds;
     const analyzers = [
       ...(config.dynamodb?.enabled === true
-        ? [new FullTableScanAnalyzer(), new MissingGSIAnalyzer(), new HotPartitionAnalyzer()]
+        ? [
+            new FullTableScanAnalyzer(),
+            new MissingGSIAnalyzer(),
+            new HotPartitionAnalyzer(hotPartitionThreshold, hotPartitionThresholds),
+          ]
         : []),
       ...(config.postgres?.enabled
         ? [new MissingIndexAnalyzer(), new NplusOneAnalyzer(), new LargeSelectAnalyzer()]
@@ -566,9 +572,15 @@ export async function runCodeRefresh(
     servicesMeta,
   );
 
+  const hotPartitionThreshold = config.analysis?.hotPartitionThreshold;
+  const hotPartitionThresholds = config.analysis?.hotPartitionThresholds;
   const analyzers = [
     ...(config.dynamodb?.enabled === true
-      ? [new FullTableScanAnalyzer(), new MissingGSIAnalyzer(), new HotPartitionAnalyzer()]
+      ? [
+          new FullTableScanAnalyzer(),
+          new MissingGSIAnalyzer(),
+          new HotPartitionAnalyzer(hotPartitionThreshold, hotPartitionThresholds),
+        ]
       : []),
     ...(config.postgres?.enabled
       ? [new MissingIndexAnalyzer(), new NplusOneAnalyzer(), new LargeSelectAnalyzer()]

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -69,6 +69,11 @@ export const InfrawiseConfigSchema = z.object({
   analysis: z
     .object({
       sampleSize: z.number().int().positive().optional().default(100),
+      hotPartitionThreshold: z.number().int().positive().optional().default(5),
+      hotPartitionThresholds: z
+        .record(z.string(), z.number().int().positive())
+        .optional()
+        .default({}),
     })
     .optional(),
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -396,6 +396,8 @@ export interface InfrawiseConfig {
   };
   analysis?: {
     sampleSize?: number;
+    hotPartitionThreshold?: number;
+    hotPartitionThresholds?: Record<string, number>;
   };
 }
 


### PR DESCRIPTION
## Summary
- add global and per-table `analysis` config for `HotPartitionAnalyzer`
- wire configured thresholds into both analyze and code refresh analyzer paths
- document the new config keys and add analyzer coverage for per-table overrides

Closes #57

## Validation
- `npm run format && npm run lint && npm run typecheck && npm test`
