### PR TITLE
feat(server): roll up source outcomes in dataHealth (sourcesAttempted/Succeeded/Partial/Failed/Disabled)

### DIFF
--- a/src/cli/__tests__/check.test.ts
+++ b/src/cli/__tests__/check.test.ts
@@ -1,0 +1,59 @@
+// Copyright 2026 ManSio
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+import { describe, it, expect } from 'vitest';
+import { evaluateCheck } from '../commands/check.js';
+import type { Finding } from '../../types.js';
+
+function finding(severity: Finding['severity'], issue = 'planted'): Finding {
+  return { severity, issue, description: '', recommendation: '' };
+}
+
+describe('evaluateCheck — negative controls for the CI gate', () => {
+  it('a planted HIGH finding must flip the verdict (check would fail)', () => {
+    const { violations } = evaluateCheck([finding('high')]);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].severity).toBe('high');
+  });
+
+  it('a clean finding set passes', () => {
+    expect(evaluateCheck([finding('low')]).violations).toHaveLength(0);
+    expect(evaluateCheck([]).violations).toHaveLength(0);
+  });
+
+  it('below-threshold findings pass with the default failOn=high', () => {
+    expect(
+      evaluateCheck([finding('medium'), finding('low'), finding('verify')]).violations,
+    ).toHaveLength(0);
+  });
+
+  it('failOn=medium promotes medium findings to violations', () => {
+    const { violations } = evaluateCheck([finding('medium'), finding('low')], 'medium');
+    expect(violations).toHaveLength(1);
+    expect(violations[0].severity).toBe('medium');
+  });
+
+  it('surfaces failed extraction sources — half-read infra cannot look clean', () => {
+    const { failedSources } = evaluateCheck([], 'high', [
+      { service: 'sqs', status: 'failed', error: 'AccessDenied: sqs:ListQueues' },
+      { service: 'lambda', status: 'ok' },
+      { service: 's3', status: 'disabled' },
+    ]);
+    expect(failedSources).toHaveLength(1);
+    expect(failedSources[0].service).toBe('sqs');
+    expect(failedSources[0].error).toContain('AccessDenied');
+  });
+
+  it('a planted HIGH finding still fails the gate even when other sources failed', () => {
+    const { violations, failedSources } = evaluateCheck([finding('high')], 'high', [
+      { service: 'rds', status: 'failed', error: 'timeout' },
+    ]);
+    expect(violations).toHaveLength(1);
+    expect(failedSources).toHaveLength(1);
+  });
+});

--- a/src/cli/commands/check.ts
+++ b/src/cli/commands/check.ts
@@ -2,7 +2,12 @@ import * as path from 'path';
 import chalk from 'chalk';
 import { readCache, setCacheDir } from '../../core/index.js';
 
-import { SEVERITY_ORDER, type Finding, type AnalysisProvenance } from '../../types.js';
+import {
+  SEVERITY_ORDER,
+  type Finding,
+  type AnalysisProvenance,
+  type SourceStatus,
+} from '../../types.js';
 import { printFinding, log, printHeader } from '../utils.js';
 import { runAnalyze } from './analyze.js';
 
@@ -12,9 +17,32 @@ interface CheckOptions {
   failOn?: 'high' | 'medium' | 'low';
 }
 
+export interface CheckEvaluation {
+  violations: Finding[];
+  failedSources: SourceStatus[];
+}
+
+/**
+ * Pure decision logic of `infrawise check` — separated from runCheck so
+ * the CI gate is unit-testable WITHOUT AWS (negative controls): a planted
+ * HIGH finding must flip the verdict, a clean set must pass, and failed
+ * extraction sources must be surfaced so a green check on half-read
+ * infrastructure cannot be mistaken for a clean one.
+ */
+export function evaluateCheck(
+  findings: Finding[],
+  failOn: 'high' | 'medium' | 'low' = 'high',
+  sources: SourceStatus[] = [],
+): CheckEvaluation {
+  const threshold = SEVERITY_ORDER[failOn] ?? 3;
+  return {
+    violations: findings.filter((f) => (SEVERITY_ORDER[f.severity] ?? 0) >= threshold),
+    failedSources: sources.filter((s) => s.status === 'failed'),
+  };
+}
+
 export async function runCheck(options: CheckOptions = {}): Promise<void> {
   const failOn = options.failOn ?? 'high';
-  const threshold = SEVERITY_ORDER[failOn] ?? 3;
 
   printHeader('Infrawise Check');
 
@@ -27,13 +55,10 @@ export async function runCheck(options: CheckOptions = {}): Promise<void> {
   // "nothing was read" rather than "nothing is wrong".
   const findings = readCache<Finding[]>('findings') ?? [];
 
-  const violations = findings.filter((f) => (SEVERITY_ORDER[f.severity] ?? 0) >= threshold);
-
-  // A source that failed to extract produces no findings, which is not the same
-  // as producing no problems. Say so before any pass/fail line, so a green check
-  // on half-read infrastructure cannot be mistaken for a clean one.
-  const failedSources = (readCache<AnalysisProvenance>('provenance')?.sources ?? []).filter(
-    (s) => s.status === 'failed',
+  const { violations, failedSources } = evaluateCheck(
+    findings,
+    failOn,
+    readCache<AnalysisProvenance>('provenance')?.sources ?? [],
   );
   if (failedSources.length > 0) {
     console.log('');

--- a/src/server/__tests__/server.test.ts
+++ b/src/server/__tests__/server.test.ts
@@ -616,10 +616,21 @@ describe('MCP Server — dataHealth envelope', () => {
         'region',
         'requestedMaxAgeSeconds',
         'sources',
+        'sourcesAttempted',
+        'sourcesDisabled',
+        'sourcesFailed',
+        'sourcesPartial',
+        'sourcesSucceeded',
         'suggestRefresh',
         'withinRequestedAge',
       ]);
       expect(data.dataHealth.sources).toEqual([{ service: 'lambda', status: 'ok', error: null }]);
+      // per-tool rollup reflects only the tool-scoped sources above
+      expect(data.dataHealth.sourcesAttempted).toBe(1);
+      expect(data.dataHealth.sourcesSucceeded).toBe(1);
+      expect(data.dataHealth.sourcesPartial).toEqual([]);
+      expect(data.dataHealth.sourcesFailed).toEqual([]);
+      expect(data.dataHealth.sourcesDisabled).toBe(0);
       expect(data.dataHealth.refreshWith).toBe('infrawise analyze');
     } finally {
       await client.close();
@@ -636,6 +647,21 @@ describe('MCP Server — dataHealth envelope', () => {
       // The cached graph still holds whatever the last good read found. The
       // point is that the caller can see the list is not authoritative.
       expect(data.dataHealth.sources[0].status).toBe('failed');
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('rolls up sources at graph scope: attempted vs succeeded vs failed/disabled', async () => {
+    const client = await clientWith(prov());
+    try {
+      const data = await callTool(client, 'get_infra_overview');
+      // sqs failed + lambda ok + s3 disabled → attempted 2, succeeded 1
+      expect(data.dataHealth.sourcesAttempted).toBe(2);
+      expect(data.dataHealth.sourcesSucceeded).toBe(1);
+      expect(data.dataHealth.sourcesPartial).toEqual([]);
+      expect(data.dataHealth.sourcesFailed).toEqual(['sqs']);
+      expect(data.dataHealth.sourcesDisabled).toBe(1);
     } finally {
       await client.close();
     }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -10,6 +10,7 @@ import type {
   Finding,
   GraphEdge,
   AnalysisProvenance,
+  SourceStatus,
   InfrawiseConfig,
 } from '../types.js';
 import { logger } from '../core/index.js';
@@ -196,12 +197,43 @@ function withNodeSource(nodes: SystemGraph['nodes']) {
   });
 }
 
+// Compact rollup of the per-source array — the "eligible_seen at a glance":
+// how many sources were actually queried this run vs fully succeeded, and
+// exactly which ones came back partial or failed. Computed from the SAME
+// tool-scoped `sources` list that is returned, so the rollup always agrees
+// with the per-source detail below it.
+interface SourceRollup {
+  /** Sources actually queried this run (ok + failed + partial — excludes disabled). */
+  sourcesAttempted: number;
+  /** Sources that fully succeeded. */
+  sourcesSucceeded: number;
+  /** Service names with partial data — gap, but usable. */
+  sourcesPartial: string[];
+  /** Service names that errored — their results are stale or empty. */
+  sourcesFailed: string[];
+  /** Sources configured out (not enabled in infrawise.yaml). */
+  sourcesDisabled: number;
+}
+
+function rollupSources(
+  sources: { service: string; status: SourceStatus['status'] }[],
+): SourceRollup {
+  return {
+    sourcesAttempted: sources.filter((s) => s.status !== 'disabled').length,
+    sourcesSucceeded: sources.filter((s) => s.status === 'ok').length,
+    sourcesPartial: sources.filter((s) => s.status === 'partial').map((s) => s.service),
+    sourcesFailed: sources.filter((s) => s.status === 'failed').map((s) => s.service),
+    sourcesDisabled: sources.filter((s) => s.status === 'disabled').length,
+  };
+}
+
 function dataHealth(
   tool: { name: string; service?: string; sources?: string[] } | undefined,
   maxAgeSeconds: unknown,
 ) {
   const ageSeconds = analyzedAt === null ? null : Math.round((Date.now() - analyzedAt) / 1000);
   const requested = typeof maxAgeSeconds === 'number' ? maxAgeSeconds : null;
+  const sources = sourcesFor(tool);
   return {
     dataHealth: {
       analyzedAt: analyzedAt === null ? null : new Date(analyzedAt).toISOString(),
@@ -215,7 +247,8 @@ function dataHealth(
         requested === null || ageSeconds === null ? null : ageSeconds <= requested,
       region: provenance?.region ?? null,
       profile: provenance?.profile ?? null,
-      sources: sourcesFor(tool),
+      sources,
+      ...rollupSources(sources),
       iac: iacHealth(),
     },
   };
@@ -300,7 +333,7 @@ export function createMcpServer(): McpServer {
     'get_infra_overview',
     {
       description:
-        'Returns a compact infrastructure snapshot: service counts, all databases, queues, topics, secrets, lambdas, and high-severity findings. Call this first at the start of any database or infrastructure task to understand what services are in scope. Prefer this over get_graph_summary for quick orientation; use get_graph_summary only when you need every node, edge, and finding in full. Also returns a `configured` flag — when false, the server has no infrawise.yaml loaded (e.g. a remotely hosted instance) and all tools return empty results; a `setupHint` explains how to run infrawise locally. Every response (this one included) carries a `dataHealth` block with a fixed shape: `analyzedAt`/`ageSeconds` for when the infrastructure was read, per-source `status`, `iac` for whether cdk.out was synthed since, and `refreshWith`. On this tool `dataHealth.sources` covers every source rather than one tool\'s. A source that is not `ok` means an empty result is "not read", not "none exist".',
+        'Returns a compact infrastructure snapshot: service counts, all databases, queues, topics, secrets, lambdas, and high-severity findings. Call this first at the start of any database or infrastructure task to understand what services are in scope. Prefer this over get_graph_summary for quick orientation; use get_graph_summary only when you need every node, edge, and finding in full. Also returns a `configured` flag — when false, the server has no infrawise.yaml loaded (e.g. a remotely hosted instance) and all tools return empty results; a `setupHint` explains how to run infrawise locally. Every response (this one included) carries a `dataHealth` block with a fixed shape: `analyzedAt`/`ageSeconds` for when the infrastructure was read, per-source `status`, the rollup (`sourcesAttempted`/`sourcesSucceeded`/`sourcesPartial`/`sourcesFailed`/`sourcesDisabled`), `iac` for whether cdk.out was synthed since, and `refreshWith`. On this tool `dataHealth.sources` covers every source rather than one tool\'s. A source that is not `ok` means an empty result is "not read", not "none exist".',
       inputSchema: z.object({
         maxAgeSeconds: z
           .number()


### PR DESCRIPTION
## What changed

The per-source status array (`ok`/`failed`/`partial`/`disabled`) already existed in `dataHealth.sources`, but an agent had to parse the array to answer the eligible_seen question: *how many sources did I actually query vs fully succeed, and exactly which ones are partial/failed?* This adds the compact rollup next to the per-source detail:

- `sourcesAttempted` — sources actually queried this run (ok + failed + partial; excludes disabled)
- `sourcesSucceeded` — fully-ok sources
- `sourcesPartial` — service names with usable-but-gapped data
- `sourcesFailed` — service names that errored (their results are stale/empty)
- `sourcesDisabled` — sources configured out

Computed from the **same tool-scoped `sources` list** that is returned, so the rollup always agrees with the per-source detail below it. Tool-scoped on per-service tools (e.g. `get_lambda_overview` rolls up just lambda) and graph-wide on `get_infra_overview`.

Also updated the `get_infra_overview` description that documents the fixed dataHealth shape.

## How was this verified

- `pnpm lint` / `pnpm typecheck` / `pnpm test` (via the pre-commit hook): **447 tests across 25 files, all passing**.
- New test coverage: the fixed-shape key assertion updated (rollup fields included), plus two rollup assertions — per-tool (lambda ok → attempted 1, succeeded 1) and graph-scope (sqs failed + lambda ok + s3 disabled → attempted 2, succeeded 1, failed [sqs], disabled 1).

## Why this matters

Without it, an agent staring at `sourcesFailed: ['sqs']` has to count; with it, "8 attempted, 6 succeeded, these 2 partial" is one glance — the difference between a stale cache being visible and being mistaken for ground truth.

## Checklist

- [x] typecheck / lint / tests pass (447/447)
- [x] Tests added/updated for the new fields
- [x] Follows existing dataHealth shape conventions (camelCase, same sources scope)