### PR TITLE
test(cli): negative controls for the check gate — extract pure evaluateCheck

### DIFF
--- a/src/cli/__tests__/check.test.ts
+++ b/src/cli/__tests__/check.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { evaluateCheck } from '../commands/check.js';
+import type { Finding } from '../../types.js';
+
+function finding(severity: Finding['severity'], issue = 'planted'): Finding {
+  return { severity, issue, description: '', recommendation: '' };
+}
+
+describe('evaluateCheck — negative controls for the CI gate', () => {
+  it('a planted HIGH finding must flip the verdict (check would fail)', () => {
+    const { violations } = evaluateCheck([finding('high')]);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].severity).toBe('high');
+  });
+
+  it('a clean finding set passes', () => {
+    expect(evaluateCheck([finding('low')]).violations).toHaveLength(0);
+    expect(evaluateCheck([]).violations).toHaveLength(0);
+  });
+
+  it('below-threshold findings pass with the default failOn=high', () => {
+    expect(
+      evaluateCheck([finding('medium'), finding('low'), finding('verify')]).violations,
+    ).toHaveLength(0);
+  });
+
+  it('failOn=medium promotes medium findings to violations', () => {
+    const { violations } = evaluateCheck([finding('medium'), finding('low')], 'medium');
+    expect(violations).toHaveLength(1);
+    expect(violations[0].severity).toBe('medium');
+  });
+
+  it('surfaces failed extraction sources — half-read infra cannot look clean', () => {
+    const { failedSources } = evaluateCheck([], 'high', [
+      { service: 'sqs', status: 'failed', error: 'AccessDenied: sqs:ListQueues' },
+      { service: 'lambda', status: 'ok' },
+      { service: 's3', status: 'disabled' },
+    ]);
+    expect(failedSources).toHaveLength(1);
+    expect(failedSources[0].service).toBe('sqs');
+    expect(failedSources[0].error).toContain('AccessDenied');
+  });
+
+  it('a planted HIGH finding still fails the gate even when other sources failed', () => {
+    const { violations, failedSources } = evaluateCheck([finding('high')], 'high', [
+      { service: 'rds', status: 'failed', error: 'timeout' },
+    ]);
+    expect(violations).toHaveLength(1);
+    expect(failedSources).toHaveLength(1);
+  });
+});

--- a/src/cli/commands/check.ts
+++ b/src/cli/commands/check.ts
@@ -2,7 +2,12 @@ import * as path from 'path';
 import chalk from 'chalk';
 import { readCache, setCacheDir } from '../../core/index.js';
 
-import { SEVERITY_ORDER, type Finding, type AnalysisProvenance } from '../../types.js';
+import {
+  SEVERITY_ORDER,
+  type Finding,
+  type AnalysisProvenance,
+  type SourceStatus,
+} from '../../types.js';
 import { printFinding, log, printHeader } from '../utils.js';
 import { runAnalyze } from './analyze.js';
 
@@ -12,9 +17,25 @@ interface CheckOptions {
   failOn?: 'high' | 'medium' | 'low';
 }
 
+export interface CheckEvaluation {
+  violations: Finding[];
+  failedSources: SourceStatus[];
+}
+
+export function evaluateCheck(
+  findings: Finding[],
+  failOn: 'high' | 'medium' | 'low' = 'high',
+  sources: SourceStatus[] = [],
+): CheckEvaluation {
+  const threshold = SEVERITY_ORDER[failOn] ?? 3;
+  return {
+    violations: findings.filter((f) => (SEVERITY_ORDER[f.severity] ?? 0) >= threshold),
+    failedSources: sources.filter((s) => s.status === 'failed'),
+  };
+}
+
 export async function runCheck(options: CheckOptions = {}): Promise<void> {
   const failOn = options.failOn ?? 'high';
-  const threshold = SEVERITY_ORDER[failOn] ?? 3;
 
   printHeader('Infrawise Check');
 
@@ -27,13 +48,10 @@ export async function runCheck(options: CheckOptions = {}): Promise<void> {
   // "nothing was read" rather than "nothing is wrong".
   const findings = readCache<Finding[]>('findings') ?? [];
 
-  const violations = findings.filter((f) => (SEVERITY_ORDER[f.severity] ?? 0) >= threshold);
-
-  // A source that failed to extract produces no findings, which is not the same
-  // as producing no problems. Say so before any pass/fail line, so a green check
-  // on half-read infrastructure cannot be mistaken for a clean one.
-  const failedSources = (readCache<AnalysisProvenance>('provenance')?.sources ?? []).filter(
-    (s) => s.status === 'failed',
+  const { violations, failedSources } = evaluateCheck(
+    findings,
+    failOn,
+    readCache<AnalysisProvenance>('provenance')?.sources ?? [],
   );
   if (failedSources.length > 0) {
     console.log('');


### PR DESCRIPTION
Extracts the decision logic of `infrawise check` into a pure `evaluateCheck(findings, failOn, sources)` so the CI gate is unit-testable without AWS, and covers it with negative controls:

- a planted HIGH finding flips the verdict (gate would fail)
- clean / below-threshold sets pass (default failOn=high)
- failOn=medium promotes medium findings
- failed extraction sources are surfaced — half-read infra cannot look clean
- a HIGH finding still fails the gate even when other sources failed

`runCheck` now delegates to `evaluateCheck` with identical behavior (threshold filter + failed-source detection) — no behavior change, only testability.

This is the accepted half of #108 per the review: the dataHealth rollup commit was declined and is not included here. Per the review feedback, this PR drops the license header and the JSDoc block — house style is no docstrings.