### PR TITLE
feat(scripts): add check:docs — release gate for version and MCP tool list sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,8 @@
 
 Before running `pnpm release <patch|minor|major>`, every item below must be current. Check each one — do not skip.
 
+Run `pnpm check:docs` — it fails if the version (`package.json`/`server.json`/website) or the MCP tool list in `README.md`/`AGENTS.md`/`llms.txt` drifted from `src/server/index.ts`. Fix the docs; do not release with it red.
+
 **Files to verify are in sync:**
 
 | File | What to check |

--- a/README.md
+++ b/README.md
@@ -558,6 +558,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for a full walkthrough — including how 
 
 ### Releasing
 
+Before releasing, run `pnpm check:docs` — it fails if the version or the MCP tool list in `README.md`/`AGENTS.md`/`llms.txt` drifted from `src/server/index.ts`.
+
 ```bash
 pnpm release patch    # 0.1.2 → 0.1.3  (bug fixes)
 pnpm release minor    # 0.1.2 → 0.2.0  (new features, backwards compatible)

--- a/llms.txt
+++ b/llms.txt
@@ -18,6 +18,7 @@ Infrawise answers all of these via 22 MCP tools served over Streamable HTTP.
 - [README](https://github.com/Sidd27/infrawise/blob/main/README.md)
 - [MCP tool reference](https://github.com/Sidd27/infrawise/blob/main/AGENTS.md)
 - [AI agent instructions](https://github.com/Sidd27/infrawise/blob/main/AGENTS.md)
+- release gate: `pnpm check:docs` keeps the version and this MCP tool list in sync with `src/server/index.ts`
 
 ## Quick start
 

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "typecheck": "tsc",
     "format": "prettier --write src",
     "build-arch": "node scripts/build-arch.mjs",
+    "check:docs": "node scripts/check-docs.mjs",
     "record": "bash docs/demo/record.sh",
     "dev": "node dist/cli/index.js serve",
     "release": "node scripts/release.js",

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+// check-docs.mjs — release gate: version and MCP tool list in the docs must stay
+// in sync with the code. Exit 0 = in sync, exit 1 = mismatches printed.
+//
+// Checks:
+//   1. package.json version == server.json version == website softwareVersion
+//   2. TOOLS in src/server/index.ts == `### \`name\`` sections in AGENTS.md
+//      == `| \`name\` |` rows in README.md == `- \`name\`` bullets in llms.txt
+//   3. No tool documented that the server does not register, and vice versa
+//   4. The "exposes N tools" count in AGENTS.md matches the real number
+//
+// Usage: node scripts/check-docs.mjs
+
+import { readFileSync } from 'node:fs'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dir = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(__dir, '..')
+const read = (rel) => readFileSync(resolve(ROOT, rel), 'utf-8')
+
+const errors = []
+const ok = (msg) => console.log(`  ✓ ${msg}`)
+const fail = (msg) => {
+  errors.push(msg)
+  console.error(`  ✗ ${msg}`)
+}
+
+// ─── 1. Version ──────────────────────────────────────────────────────────────
+const pkg = JSON.parse(read('package.json'))
+const manifest = JSON.parse(read('server.json'))
+const astro = read('website/src/pages/index.astro')
+const astroVersion = astro.match(/"softwareVersion"\s*:\s*"([^"]+)"/)?.[1]
+
+const versions = [
+  ['package.json', pkg.version],
+  ['server.json', manifest.version],
+  ['website softwareVersion', astroVersion ?? null],
+]
+console.log('Version:')
+for (const [file, v] of versions) {
+  v === pkg.version ? ok(`${file} = ${v}`) : fail(`${file} = ${v} (expected ${pkg.version})`)
+}
+
+// ─── 2. Tool list ────────────────────────────────────────────────────────────
+const server = read('src/server/index.ts')
+const toolsBlock = server.match(/export const TOOLS[\s\S]*?= \[([\s\S]*?)\n\];/)
+if (!toolsBlock) fail('src/server/index.ts: TOOLS array not found')
+const tools = toolsBlock
+  ? [...toolsBlock[1].matchAll(/name:\s*'([a-z0-9_]+)'/g)].map((m) => m[1])
+  : []
+if (tools.length > 0) ok(`src/server/index.ts: ${tools.length} tools`)
+
+const toolsSet = new Set(tools)
+
+const ag = read('AGENTS.md')
+const readme = read('README.md')
+const llms = read('llms.txt')
+
+const agSections = [...ag.matchAll(/^### `([a-z0-9_]+)`/gm)].map((m) => m[1])
+const readmeRows = [...readme.matchAll(/^\| `([a-z0-9_]+)`/gm)].map((m) => m[1])
+const llmsBullets = [...llms.matchAll(/^- `([a-z0-9_]+)`/gm)].map((m) => m[1])
+const agCount = ag.match(/exposes (\d+) tools via MCP/)?.[1]
+
+const docs = [
+  ['AGENTS.md', agSections],
+  ['README.md', readmeRows],
+  ['llms.txt', llmsBullets],
+]
+
+console.log('Tool list:')
+for (const [file, found] of docs) {
+  const foundSet = new Set(found)
+  const missing = tools.filter((t) => !foundSet.has(t))
+  const extra = [...foundSet].filter((t) => !toolsSet.has(t))
+  missing.forEach((t) => fail(`${file}: missing tool \`${t}\``))
+  extra.forEach((t) => fail(`${file}: tool \`${t}\` not registered in src/server/index.ts`))
+  if (found.length !== tools.length && missing.length === 0 && extra.length === 0) {
+    fail(`${file}: ${found.length} tool entries, expected ${tools.length}`)
+  }
+  if (missing.length === 0 && extra.length === 0 && found.length === tools.length) {
+    ok(`${file}: ${found.length} tools`)
+  }
+}
+
+if (agCount) {
+  Number(agCount) === tools.length
+    ? ok(`AGENTS.md: "exposes ${agCount} tools via MCP"`)
+    : fail(`AGENTS.md: "exposes ${agCount} tools via MCP" (expected ${tools.length})`)
+}
+
+console.log('')
+if (errors.length > 0) {
+  console.error(`check:docs failed — ${errors.length} mismatch(es). Run pnpm check:docs before release.`)
+  process.exit(1)
+}
+console.log('check:docs passed — docs are in sync with the code.')


### PR DESCRIPTION
## What

Adds `pnpm check:docs` — a release gate that automates the two drift-prone parts of the pre-release checklist that #108 tripped over:

1. **Version sync** — `package.json` version must equal `server.json` version and the website `softwareVersion` in `website/src/pages/index.astro`.
2. **MCP tool list sync** — the `TOOLS` array in `src/server/index.ts` must match, in both directions:
   - `### \`tool\`` sections in `AGENTS.md`
   - `| \`tool\` |` rows in `README.md`
   - `- \`tool\` —` bullets in `llms.txt`
   - the "exposes N tools via MCP" count in `AGENTS.md`

A tool documented but not registered, or registered but not documented, fails the check by name. Exit 0 = in sync, exit 1 = every mismatch printed. No new dependencies — plain Node script in `scripts/` next to `build-arch.mjs` / `release.js`.

## Why

The pre-release checklist ("check each one, do not skip") is manual. #108 shipped a `dataHealth` shape change that only updated the tool description string, and the doc set silently diverged. A guard that runs in seconds replaces eyeballing six files.

## How it was verified (experiments, not just unit tests)

- **Positive control:** run on the current in-sync docs → passes, 22 tools everywhere.
- **Negative control (guard must be able to fail):** appended a bogus tool bullet to `llms.txt` → fails with `✗ llms.txt: tool \`get_bogus_tool\` not registered in src/server/index.ts`; reverted → passes again.
- The first run caught a bug in the checker itself: the name regex `[a-z_]+` does not match the digit in `get_s3_overview` (same class of bug as the audit that missed it), so it reported 21 ≠ 22. Fixed to `[a-z0-9_]+` and re-verified — this is exactly why a guard gets a fail-path test before shipping.

## Trade-offs

**+** Automates ~80% of the drift-prone checklist; runs in <1s; zero deps; both drift directions caught; fails loudly with the exact file and name.
**−** Regex-based parsing of the docs is anchored to the canonical forms (section headers, table rows, bullets) — a doc that renames its sections breaks the check and needs the script updated. The version check reads the astro file as text; a refactor of the JSON-LD block must keep the `"softwareVersion"` key.

## Nuances / pitfalls

- `get_s3_overview` contains a digit — any name regex must allow `[0-9]`, not just `[a-z_]`.
- `llms.txt` carries a non-tool bullet (`dataHealth.suggestRefresh`) that also starts with `` ` `` after the dash — the anchors (`` `name` `` immediately after the marker) are what keep prose mentions out of the count.
- `server.json` deliberately has no tool count (per repo rule) — the checker does not require one, so the two drift risks there are version-only.
- CONTRIBUTING.md's PR checklist gains a `check:docs` item in a follow-up once the house-rules PR (#115) lands, to avoid two PRs editing the same file.

## Docs updated

- `AGENTS.md` — pre-release checklist now opens with "Run `pnpm check:docs`".
- `README.md` — "Releasing" section mentions the gate.
- `llms.txt` — Docs section lists the release gate.
