### PR TITLE
test(analyzers): audit negative-control coverage and close the compositeLink gap

### DIFF
--- a/src/analyzers/__tests__/linkers.test.ts
+++ b/src/analyzers/__tests__/linkers.test.ts
@@ -150,4 +150,9 @@ describe('compositeLink', () => {
     });
     expect(links).toHaveLength(2);
   });
+
+  it('returns no links when neither linker finds a match', () => {
+    const g = graphWith('alpha', 'beta', 'src/beta.ts');
+    expect(compositeLink([], g)).toEqual([]);
+  });
 });


### PR DESCRIPTION
## What

A systematic audit of negative-control coverage across every analyzer test file, plus the one real gap it found, fixed.

**Audit method:** per `describe` block, mapped each analyzer to whether it has at least one negative assertion (`toHaveLength(0)`, `toEqual([])`, or `toBeUndefined()`). 55 analyzer blocks across 10 test files were classified.

**Result:** negative coverage is already strong — every critical analyzer the mutation-testing principle targets has real, non-vacuous negative fixtures:

- `MissingDLQAnalyzer` — "does not flag queue that has a DLQ", placeholder queues, non-queue nodes
- `VisibilityTimeoutMismatchAnalyzer` — "does not flag when visibility timeout is at least 6x the Lambda timeout"
- `MissingGSIAnalyzer` — "does not flag table that has a GSI"
- `S3PublicAccessAnalyzer` — "does not flag bucket with public access blocked", silent on never-read buckets
- `LambdaDefaultMemoryAnalyzer` / `LambdaHighTimeoutAnalyzer` — higher memory / below-300s negatives
- `IaCDriftAnalyzer` — in-sync graph → 0 findings (parent-level negative covering DynamoDB + SQS + Lambda), plus empty-schema and no-IaC negatives

**The gap:** `compositeLink` in `src/analyzers/linkers.test.ts` had only a positive case. Added "returns no links when neither linker finds a match" — a no-match graph must yield an empty link set, proving the helper returns nothing rather than being assumed to.

## Why

CONTRIBUTING.md already mandates "at least one positive and one negative test case" per analyzer. This PR makes that standard verifiable: the audit is the evidence, the added test closes the only hole found. It deliberately does **not** add redundant per-type drift negatives — the IaC in-sync negative already exercises all three resource types together, and duplicating it per `describe` would add noise without catching anything new (a combined fixture isolates nothing worse than a per-type one would, and the existing per-type positives pin each direction).

## Trade-offs

**+** Closes the last no-negative block among analyzers; audit methodology is reproducible (`describe` → negative-assertion map).
**−** Small PR by design — the audit's finding is that the repo is already in good shape, not that much was missing. A PR that only adds redundant tests would be gold-plating.

## Nuances / pitfalls

- A negative case must be non-vacuous: an empty graph trivially yields no findings. The strong negatives in this repo use a fixture where the resource *exists* but the condition is absent (queue with a DLQ, bucket with a block, table with a GSI). The audit counted only assertion patterns; fixtures like "returns empty findings for empty graph" are deliberately weaker and fine as extras.
- `toBeUndefined()` is the negative idiom for cost-signal helpers — a narrow `toHaveLength(0)` audit would miss them (the first audit pass did; it was broadened).

## Verification

`pnpm vitest run src/analyzers/__tests__/linkers.test.ts` — 9/9 pass. Full suite via pre-commit hook: 447/447 (446 + the new test), typecheck and lint clean.
