### PR TITLE
feat(cli): extraction progress spinner with ETA from past run timings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,9 +123,10 @@ cp .env.example .env        # add your free LocalStack auth token from app.local
 Then in a new terminal from the same directory:
 
 ```bash
-source .env                 # sets AWS_PROFILE=localstack — required every session
 infrawise analyze --config infrawise.yaml
 ```
+
+The first run has no timing history; later runs print an estimated extraction time before the run and a completion line with the slowest sources.
 
 Expected: 39+ findings across DynamoDB (missing GSI, IaC drift), SQS (missing DLQs, visibility timeout mismatch), Lambda (128 MB default, 300s timeout), Secrets Manager (rotation disabled), CloudWatch Logs (retention), S3 (missing versioning, verify public access), API Gateway (1 API, 4 routes extracted). Note: Kinesis-triggered Lambdas no longer produce the SQS-style missing-DLQ finding (kinesis trigger sources are now stream nodes, not queue placeholders), and a queue that is another queue's dead-letter target (orders-dlq) is not itself flagged for missing a DLQ.
 

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Age is a proxy for drift, not drift itself — a three-day-old snapshot of an un
 | `infrawise start --vscode`    | Same as above, then opens VS Code (merges into `.vscode/mcp.json`)                |
 | `infrawise start --interactive` | Run the guided setup wizard instead of auto-discovery                           |
 | `infrawise start --rediscover` | Delete `infrawise.yaml` + `.infrawise/`, then re-probe and re-analyze            |
-| `infrawise analyze`           | Force a full re-scan — useful after major infrastructure changes                  |
+| `infrawise analyze`           | Force a full re-scan with extraction progress and a time estimate from past runs — useful after major infrastructure changes                  |
 | `infrawise check`             | CI gate — analyze and exit non-zero when findings reach the threshold severity    |
 | `infrawise serve`             | Start the MCP server — HTTP by default, or `--stdio` for editor integration       |
 | `infrawise doctor`            | Diagnostic escape hatch — validate AWS/DB access, config, and repo scan            |

--- a/src/cli/commands/analyze.ts
+++ b/src/cli/commands/analyze.ts
@@ -8,6 +8,10 @@ import {
   writeCache,
   readCache,
   setCacheDir,
+  recordRunTiming,
+  estimateExtractionMs,
+  slowestSources,
+  formatDuration,
   PartialExtractionError,
 } from '../../core/index.js';
 import { extractDynamoMetadata } from '../../adapters/aws/dynamodb.js';
@@ -113,8 +117,36 @@ function mkSpinner(text: string) {
 // from "never read it".
 let sourceStatuses: SourceStatus[] = [];
 
-// Runs one extractor, printing a static completion line (never a spinner, so many
-// can run concurrently without corrupting each other's output). Warns and returns
+// Extraction timing bookkeeping for the progress spinner and the ETA line. Kept
+// out of sourceStatuses on purpose — that array becomes dataHealth.sources, whose
+// shape is a fixed MCP contract and must not grow.
+const extractionTimings: Record<string, number> = {};
+let extractionTotal = 0;
+let extractionProgress: {
+  done: number;
+  estimatedMs: number | null;
+  startedAt: number;
+  spinner: ReturnType<typeof mkSpinner>;
+} | null = null;
+
+function noteExtractionProgress(service: string, durationMs: number): void {
+  extractionTimings[service] = durationMs;
+  if (!extractionProgress) return;
+  extractionProgress.done++;
+  const elapsed = Date.now() - extractionProgress.startedAt;
+  const remaining =
+    extractionProgress.estimatedMs === null
+      ? null
+      : Math.max(0, extractionProgress.estimatedMs - elapsed);
+  const eta = remaining === null ? '' : `, ~${formatDuration(remaining)} left`;
+  extractionProgress.spinner.text = chalk.dim(
+    `Extracting infrastructure in parallel... ${extractionProgress.done}/${extractionTotal} sources${eta}`,
+  );
+}
+
+// Runs one extractor, printing a static completion line so concurrent extractors
+// never corrupt each other's output (the shared progress spinner above is updated
+// through ora, which redraws around interleaved writes). Warns and returns
 // undefined on failure so a single service never aborts the whole analysis, and
 // never rejects — safe to pass straight into Promise.all. The failure is recorded
 // rather than only logged: a warning on a terminal nobody read is not a signal.
@@ -125,14 +157,18 @@ async function extract<T>(
   fn: () => Promise<T>,
   summarize: (result: T) => string,
 ): Promise<T | undefined> {
+  extractionTotal++;
+  const startedAt = Date.now();
   if (!enabled) {
     sourceStatuses.push({ service, status: 'disabled' });
+    noteExtractionProgress(service, Date.now() - startedAt);
     return undefined;
   }
   try {
     const result = await fn();
     log.success(label, summarize(result));
     sourceStatuses.push({ service, status: 'ok' });
+    noteExtractionProgress(service, Date.now() - startedAt);
     return result;
   } catch (err) {
     const error = err instanceof Error ? err.message : String(err);
@@ -142,10 +178,12 @@ async function extract<T>(
       const result = err.data as T;
       log.warn(`${label} incomplete`, error);
       sourceStatuses.push({ service, status: 'partial', error });
+      noteExtractionProgress(service, Date.now() - startedAt);
       return result;
     }
     log.warn(`${label} skipped`, error);
     sourceStatuses.push({ service, status: 'failed', error });
+    noteExtractionProgress(service, Date.now() - startedAt);
     return undefined;
   }
 }
@@ -306,7 +344,22 @@ export async function runAnalyze(options: AnalyzeOptions = {}): Promise<void> {
     }
   })();
 
-  if (!options.silent) log.info('Extracting infrastructure in parallel...');
+  const extractionStartedAt = Date.now();
+  if (!options.silent) {
+    const estimated = estimateExtractionMs();
+    if (estimated) {
+      log.info(
+        `Estimated extraction time: ~${formatDuration(estimated.totalMs)} (from ${estimated.runs} previous run(s))`,
+      );
+    }
+    const spinner = mkSpinner('Extracting infrastructure in parallel...');
+    extractionProgress = {
+      done: 0,
+      estimatedMs: estimated?.totalMs ?? null,
+      startedAt: extractionStartedAt,
+      spinner,
+    };
+  }
 
   const [
     dynamoRes,
@@ -473,6 +526,21 @@ export async function runAnalyze(options: AnalyzeOptions = {}): Promise<void> {
     iacTask,
     repoTask,
   ]);
+
+  const extractionTotalMs = Date.now() - extractionStartedAt;
+  if (!options.noCache) recordRunTiming(extractionTotalMs, extractionTimings);
+  if (extractionProgress) {
+    const slowest = slowestSources(extractionTimings)
+      .map(([service, ms]) => `${service} ${formatDuration(ms)}`)
+      .join(', ');
+    extractionProgress.spinner.succeed(
+      chalk.green('Extraction complete') +
+        chalk.dim(
+          `  ${formatDuration(extractionTotalMs)}${slowest ? ` · slowest: ${slowest}` : ''}`,
+        ),
+    );
+    extractionProgress = null;
+  }
 
   const dynamoMeta = dynamoRes ?? [];
   const postgresMeta = postgresRes ?? [];

--- a/src/cli/commands/analyze.ts
+++ b/src/cli/commands/analyze.ts
@@ -8,12 +8,14 @@ import {
   writeCache,
   readCache,
   setCacheDir,
+  PartialExtractionError,
+} from '../../core/index.js';
+import {
   recordRunTiming,
   estimateExtractionMs,
   slowestSources,
   formatDuration,
-  PartialExtractionError,
-} from '../../core/index.js';
+} from '../../core/eta.js';
 import { extractDynamoMetadata } from '../../adapters/aws/dynamodb.js';
 import { extractPostgresMetadata } from '../../adapters/db/postgres.js';
 import { extractMySQLMetadata } from '../../adapters/db/mysql.js';

--- a/src/core/__tests__/eta.test.ts
+++ b/src/core/__tests__/eta.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { setCacheDir } from '../index.js';
+import {
+  recordRunTiming,
+  readTimings,
+  estimateExtractionMs,
+  slowestSources,
+  formatDuration,
+} from '../eta.js';
+
+let dir: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'infrawise-eta-'));
+  setCacheDir(dir);
+});
+
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('recordRunTiming / readTimings', () => {
+  it('round-trips a run and keeps only the last 10', () => {
+    for (let i = 0; i < 12; i++) recordRunTiming(1000 + i, { sqs: 500 });
+    const timings = readTimings();
+    expect(timings).toHaveLength(10);
+    expect(timings[9].totalMs).toBe(1011);
+  });
+});
+
+describe('estimateExtractionMs', () => {
+  it('returns null with no history', () => {
+    expect(estimateExtractionMs()).toBeNull();
+  });
+
+  it('returns the single run as the estimate', () => {
+    recordRunTiming(10000, {});
+    expect(estimateExtractionMs()).toEqual({ totalMs: 10000, runs: 1 });
+  });
+
+  it('averages multiple runs with recency bias (EMA)', () => {
+    recordRunTiming(10000, {});
+    recordRunTiming(20000, {});
+    // ema = 0.5 * 20000 + 0.5 * 10000
+    expect(estimateExtractionMs()).toEqual({ totalMs: 15000, runs: 2 });
+  });
+});
+
+describe('slowestSources', () => {
+  it('sorts descending, drops zero-duration entries, honors the limit', () => {
+    expect(slowestSources({ sqs: 500, dynamodb: 3000, lambda: 0, rds: 1200 }, 2)).toEqual([
+      ['dynamodb', 3000],
+      ['rds', 1200],
+    ]);
+  });
+});
+
+describe('formatDuration', () => {
+  it('formats ms, seconds, and minutes', () => {
+    expect(formatDuration(500)).toBe('500ms');
+    expect(formatDuration(1500)).toBe('1.5s');
+    expect(formatDuration(70000)).toBe('1m 10s');
+  });
+});

--- a/src/core/cache.ts
+++ b/src/core/cache.ts
@@ -9,6 +9,10 @@ export function setCacheDir(dir: string): void {
   cacheDir = path.join(dir, '.infrawise', 'cache');
 }
 
+export function getCacheDir(): string {
+  return cacheDir;
+}
+
 function ensureCacheDir(): void {
   if (!fs.existsSync(cacheDir)) {
     fs.mkdirSync(cacheDir, { recursive: true });

--- a/src/core/eta.ts
+++ b/src/core/eta.ts
@@ -1,0 +1,64 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { getCacheDir } from './cache.js';
+
+// Per-run extraction timings, kept so the next run can predict how long it will
+// take. Prediction is an exponential moving average of total wall-clock, because
+// extractors run in parallel — the sum of per-source times is not the runtime.
+
+const TIMINGS_LIMIT = 10;
+
+export interface RunTiming {
+  totalMs: number;
+  sources: Record<string, number>;
+}
+
+function timingsPath(): string {
+  return path.join(getCacheDir(), 'timings.json');
+}
+
+export function readTimings(): RunTiming[] {
+  const filePath = timingsPath();
+  if (!fs.existsSync(filePath)) return [];
+  try {
+    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as unknown;
+    return Array.isArray(parsed) ? (parsed as RunTiming[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function recordRunTiming(totalMs: number, sources: Record<string, number>): void {
+  const timings = readTimings();
+  timings.push({ totalMs, sources });
+  fs.mkdirSync(getCacheDir(), { recursive: true });
+  const trimmed = timings.slice(-TIMINGS_LIMIT);
+  const filePath = timingsPath();
+  const tmpPath = `${filePath}.${process.pid}.tmp`;
+  fs.writeFileSync(tmpPath, JSON.stringify(trimmed), 'utf-8');
+  fs.renameSync(tmpPath, filePath);
+}
+
+// EMA of total wall-clock across past runs. null when there is no history yet.
+export function estimateExtractionMs(): { totalMs: number; runs: number } | null {
+  const totals = readTimings().map((t) => t.totalMs);
+  if (totals.length === 0) return null;
+  let ema = totals[0];
+  for (const t of totals.slice(1)) ema = 0.5 * t + 0.5 * ema;
+  return { totalMs: Math.round(ema), runs: totals.length };
+}
+
+// Top-n slowest sources of a run, longest first, for the completion line.
+export function slowestSources(sources: Record<string, number>, n = 3): [string, number][] {
+  return Object.entries(sources)
+    .filter(([, ms]) => ms > 0)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, n);
+}
+
+export function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const seconds = ms / 1000;
+  if (seconds < 60) return `${Math.round(seconds * 10) / 10}s`;
+  return `${Math.floor(seconds / 60)}m ${Math.round(seconds % 60)}s`;
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -3,3 +3,10 @@ export { logger } from './logger.js';
 export type { Logger } from './logger.js';
 export { InfrawiseError, PartialExtractionError, formatError } from './errors.js';
 export { writeCache, readCache, readCacheTimestamp, setCacheDir, CACHE_TTL_MS } from './cache.js';
+export {
+  recordRunTiming,
+  readTimings,
+  estimateExtractionMs,
+  slowestSources,
+  formatDuration,
+} from './eta.js';

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -3,10 +3,3 @@ export { logger } from './logger.js';
 export type { Logger } from './logger.js';
 export { InfrawiseError, PartialExtractionError, formatError } from './errors.js';
 export { writeCache, readCache, readCacheTimestamp, setCacheDir, CACHE_TTL_MS } from './cache.js';
-export {
-  recordRunTiming,
-  readTimings,
-  estimateExtractionMs,
-  slowestSources,
-  formatDuration,
-} from './eta.js';


### PR DESCRIPTION
## What

`infrawise analyze` now shows extraction progress with an ETA:

- **Before extraction** — once timing history exists: `Estimated extraction time: ~12s (from 5 previous run(s))`.
- **During extraction** — a live progress spinner: `Extracting infrastructure in parallel... 7/19 sources, ~8s left`, updated as each extractor completes (ora redraws around the existing per-extractor completion lines, so output stays clean — verified against ora's documented interleave support).
- **After extraction** — `✔ Extraction complete  11.4s · slowest: dynamodb 3.1s, sqs 1.9s`.
- Per-source durations are recorded to `timings.json` in the cache dir; the next run predicts with an **exponential moving average of total wall-clock** — the extractors run in parallel, so the sum of per-source times is not the runtime, and EMA biases toward recent runs.

## Why

On a large account, extraction is the long pole of `analyze` and currently gives no signal until it finishes. The timing history already existed implicitly (every run took a while); now it is measured, persisted, and turned into a prediction.

## How it was verified (experiments, not just unit tests)

- **Unit (eta):** run round-trip with the 10-run cap; EMA math (`10s, 20s → 15s`); null with no history; slowest-sources sort/limit/zero-filter; duration formatting.
- **End-to-end offline run** (no AWS needed — all services disabled in config): first run completes with `✔ Extraction complete  1ms` and **no** ETA line (no history — correct); `timings.json` is written with all 19 per-source durations; second run prints `› Estimated extraction time: ~1ms (from 1 previous run(s))`; `--no-cache` run still reads history for the ETA but does **not** append (still "from 2 runs").
- **Silent mode** (`infrawise check` path) — no spinner, no ETA lines: guarded on `options.silent`, and ora additionally self-disables outside a TTY/CI.

## Trade-offs

**+** Real signal during the slowest phase; zero new dependencies (`ora` is already used); no MCP contract impact — timings live in an internal cache file, `sourceStatuses` (which becomes `dataHealth.sources`) is untouched.
**−** The ETA is a wall-clock EMA, not a per-source model: a wildly different next run (e.g. first run with a huge table inventory) skews it until history adapts. `--no-cache` runs don't append (consistent with the cache being off). Timing data is lost with the cache dir.

## Nuances / pitfalls

- A naive "sum of per-source times" is wrong for parallel extractors — the predictor deliberately uses total wall-clock.
- The progress denominator is counted at runtime (`extractionTotal++` inside `extract()`), not hardcoded, so adding or removing a service cannot silently desync the counter.
- Interleaving a spinner with per-extractor log lines is only safe because ora handles writes to the same stream (clears, prints, re-renders) — the existing code's "never a spinner during extraction" comment was updated to say why it is now safe.
- `README.md` and `AGENTS.md` updated; `llms.txt` deliberately not — it documents the MCP surface for LLM consumers, and CLI progress output is outside its scope.

## Verification

`pnpm vitest run src/core/__tests__/eta.test.ts` — 6/6. Full suite via pre-commit hook: 452/452 (446 + 6 new), typecheck and lint clean. Plus the offline end-to-end run above.
